### PR TITLE
Fix PyJWT error handling

### DIFF
--- a/src/synapse/core/auth/jwt.py
+++ b/src/synapse/core/auth/jwt.py
@@ -59,7 +59,7 @@ class JWTManager:
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Token expirado"
             )
-        except jwt.JWTError:
+        except jwt.PyJWTError:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Token inválido"


### PR DESCRIPTION
## Summary
- catch `jwt.PyJWTError` instead of `jwt.JWTError`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_6847941dc630832b9367ab7b8dd97b98