### PR TITLE
Fix path in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Ao participar deste projeto, você concorda em seguir nosso código de conduta. 
 ```bash
 # Clone o repositório
 git clone <repository-url>
-cd synapse-backend-agents-jc-main
+cd synapse-backend-agents-jc
 
 # Configure o ambiente
 python -m venv venv


### PR DESCRIPTION
## Summary
- update repo folder name in CONTRIBUTING instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_6847978af834832b928b84329479b0de