### PR TITLE
Update token validation dependency

### DIFF
--- a/src/synapse/api/deps.py
+++ b/src/synapse/api/deps.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from src.synapse.config import settings
 from src.synapse.database import get_db
 from src.synapse.models.user import User
-from src.synapse.core.auth.jwt import verify_token, verify_token
+from src.synapse.core.auth.jwt import verify_token
 
 # Esquema de autenticação OAuth2
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_V1_STR}/auth/login")
@@ -42,10 +42,7 @@ async def get_current_user(
     )
     
     try:
-        # Verificar e decodificar token
-        if not verify_token(token):
-            raise credentials_exception
-            
+        # Decodificar token JWT
         payload = verify_token(token)
         user_id: str = payload.get("sub")
         

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -79,8 +79,7 @@ def test_login_user(client: TestClient):
 def test_get_current_user(client: TestClient):
     """Teste para obter usuário atual"""
     response = client.get("/api/v1/auth/auth/me")
-    # Pode retornar 200 (se autenticado) ou 401 (se não autenticado)
-    assert response.status_code in [200, 401]
+    assert response.status_code == 200
 
 
 @pytest.mark.api


### PR DESCRIPTION
## Summary
- fix duplicated import of `verify_token`
- simplify JWT validation in `get_current_user`
- tighten `test_get_current_user` expectations

## Testing
- `pytest` *(fails: DATABASE_URL environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_6847a3d1f9d8832b83c11305cc84b2d8