### PR TITLE
Use env var for database url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ JWT_REFRESH_TOKEN_EXPIRE_DAYS=7
 # ============================
 # CONFIGURAÇÕES DO BANCO DE DADOS
 # ============================
+# Defina a URL completa de conexão com o PostgreSQL
 DATABASE_URL=postgresql://usuario:senha@localhost:5432/synapscale_db
 DATABASE_SCHEMA=synapscale_db
 DATABASE_POOL_SIZE=20

--- a/BACKEND-ENV-RENDER-COMPLETO.env
+++ b/BACKEND-ENV-RENDER-COMPLETO.env
@@ -5,7 +5,7 @@
 # ============================
 # CONFIGURAÇÕES DO BANCO DE DADOS
 # ============================
-DATABASE_URL=postgresql://doadmin:AVNS_DDsc3wHcfGgbX_USTUt@db-banco-dados-automacoes-do-user-13851907-0.e.db.ondigitalocean.com:25060/defaultdb?sslmode=require
+DATABASE_URL=postgresql://user:password@host:port/database?sslmode=require
 DATABASE_SCHEMA=synapscale_db
 
 # ============================

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ cp .env.example .env
 # ============================
 # CONFIGURAÇÕES DO BANCO DE DADOS
 # ============================
+# Defina a variável de ambiente com a URL do banco
 DATABASE_URL=postgresql://usuario:senha@localhost:5432/synapscale_db
 DATABASE_SCHEMA=synapscale_db
 
@@ -307,6 +308,7 @@ synapse-backend-agents-jc/
 
 ```env
 DEBUG=false
+# Defina `DATABASE_URL` com sua string de conexão
 DATABASE_URL=postgresql://user:pass@prod-db:5432/synapscale
 REDIS_URL=redis://prod-redis:6379/0
 BACKEND_CORS_ORIGINS=["https://app.synapscale.com"]
@@ -322,6 +324,7 @@ services:
     ports:
       - "8000:8000"
     environment:
+      # Defina a variável com sua URL do banco
       - DATABASE_URL=postgresql://user:pass@db:5432/synapscale
     depends_on:
       - db

--- a/README_BACKEND.md
+++ b/README_BACKEND.md
@@ -31,8 +31,8 @@ Este repositório contém o backend **Synapse Backend Agents JC** completamente 
 - `.env` - Variáveis de ambiente configuradas
 - `start_backend.sh` - Script de inicialização
 
-### 🗄️ **Banco de Dados:**
-- Conexão: `postgresql://doadmin:AVNS_DDsc3wHcfGgbX_USTUt@db-banco-dados-automacoes-do-user-13851907-0.e.db.ondigitalocean.com:25060/defaultdb?sslmode=require`
+-### 🗄️ **Banco de Dados:**
+- Conexão definida pela variável de ambiente `DATABASE_URL`
 - Schema: `synapscale_db`
 - Tabelas: 53 tabelas funcionando perfeitamente
 

--- a/src/synapse/core/config_fixed.py
+++ b/src/synapse/core/config_fixed.py
@@ -17,7 +17,7 @@ class Settings(BaseSettings):
     
     # Configurações do banco de dados
     DATABASE_URL: str = Field(
-        default="postgresql://doadmin:AVNS_DDsc3wHcfGgbX_USTUt@db-banco-dados-automacoes-do-user-13851907-0.e.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+        default_factory=lambda: os.getenv("DATABASE_URL", ""),
         description="URL de conexão com o banco de dados"
     )
     DATABASE_SCHEMA: str = Field(

--- a/src/synapse/core/config_new.py
+++ b/src/synapse/core/config_new.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     
     # Configurações do banco de dados
     DATABASE_URL: str = Field(
-        default="postgresql://doadmin:AVNS_DDsc3wHcfGgbX_USTUt@db-banco-dados-automacoes-do-user-13851907-0.e.db.ondigitalocean.com:25060/defaultdb?sslmode=require",
+        default_factory=lambda: os.getenv("DATABASE_URL", ""),
         description="URL de conexão com o banco de dados"
     )
     DATABASE_SCHEMA: str = Field(


### PR DESCRIPTION
## Summary
- read DATABASE_URL from environment in new and fixed configs
- clarify DATABASE_URL usage in README files
- sanitize example env files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_b_6847a3d37960832ba183b0ab4f62398e