### PR TITLE
Fix WebSocket JWT verification

### DIFF
--- a/src/synapse/api/v1/endpoints/websockets.py
+++ b/src/synapse/api/v1/endpoints/websockets.py
@@ -33,8 +33,8 @@ async def authenticate_websocket(
     Autentica um WebSocket usando JWT token
     """
     try:
-        # Decodifica o token JWT
-        payload = jwt_manager.decode_token(token)
+        # Verifica e decodifica o token JWT
+        payload = jwt_manager.verify_token(token)
         user_id = payload.get("sub")
         
         if not user_id:

--- a/src/synapse/core/auth/jwt.py
+++ b/src/synapse/core/auth/jwt.py
@@ -208,3 +208,18 @@ def verify_token(token: str) -> Dict[str, Any]:
     """Função utilitária para verificar token"""
     return jwt_manager.verify_token(token)
 
+def decode_token(token: str) -> Dict[str, Any]:
+    """Decodifica um token JWT e retorna o payload"""
+    try:
+        payload = jwt.decode(
+            token,
+            settings.JWT_SECRET_KEY,
+            algorithms=[settings.JWT_ALGORITHM]
+        )
+        return payload
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido"
+        )
+


### PR DESCRIPTION
## Summary
- use `jwt_manager.verify_token` in WebSocket auth
- add helper `decode_token` to JWT utils

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_b_6847a3d2ec54832bafe538b1993f9e69