### PR TITLE
Update Python version to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ API robusta e escalável para gerenciamento de workflows, agentes AI e automaç�
 
 ### Pré-requisitos
 
-- Python 3.11+
-- PostgreSQL 13+
-- Redis 6+
-- Git
+ - Python 3.11
+ - PostgreSQL 13+
+ - Redis 6+
+ - Git
 
 ### 1. Clone o Repositório
 

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -8,7 +8,7 @@ Este guia fornece instruções detalhadas para desenvolvedores que desejam contr
 
 ### Pré-requisitos
 
-- Python 3.9 ou superior
+- Python 3.11 ou superior
 - Poetry (gerenciador de dependências)
 - SQLite (para desenvolvimento local)
 

--- a/docs/guia_detalhado.md
+++ b/docs/guia_detalhado.md
@@ -22,7 +22,7 @@ Antes de iniciar a instalação, certifique-se de que seu sistema atende aos seg
 
 ### Para Instalação Local
 
-- **Python**: Versão 3.9 ou superior
+- **Python**: Versão 3.11 ou superior
   - Verifique sua versão com: `python --version`
   - Caso não tenha, instale em: [python.org](https://www.python.org/downloads/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 license = "MIT"
 packages = [{include = "synapse", from = "src"}]
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.11"
 fastapi = "0.109.2"
 uvicorn = "^0.23.2"
 sqlalchemy = "^2.0.20"
@@ -40,12 +40,12 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 88
-target-version = ["py39"]
+target-version = ["py311"]
 [tool.isort]
 profile = "black"
 line_length = 88
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
- require Python 3.11 in pyproject
- document Python 3.11 support in README and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_6847af76a12c832b9605db05e6f00552