### PR TITLE
Fix WebSocket JWT verification and add decode helper

### DIFF
--- a/src/synapse/core/auth/__init__.py
+++ b/src/synapse/core/auth/__init__.py
@@ -6,6 +6,7 @@ from .jwt import (
     create_access_token,
     create_refresh_token,
     verify_token,
+    decode_token,
     get_current_user,
     get_current_active_user,
     get_current_verified_user,
@@ -19,10 +20,11 @@ from .password import (
 __all__ = [
     # JWT functions
     "require_permission",
-    "require_role", 
+    "require_role",
     "create_access_token",
     "create_refresh_token",
     "verify_token",
+    "decode_token",
     "get_current_user",
     "get_current_active_user",
     "get_current_verified_user",


### PR DESCRIPTION
## Summary
- add `decode_token` helper for WebSocket JWT authentication
- export the new helper in the auth package

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_6847b27efe24832b8bfe223a944d7c5c