### PR TITLE
Ensure httpx available for tests

### DIFF
--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -196,6 +196,8 @@ cat > test_setup.sh << 'EOF'
 #!/bin/bash
 echo "🧪 Testando configuração..."
 source venv/bin/activate
+# Ensure httpx is installed for tests
+pip install --quiet httpx
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 python3 -c "
 import requests

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 echo "🧪 Testando configuração..."
 source venv/bin/activate
+# Ensure httpx is installed for tests
+pip install --quiet httpx
 export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 python3 -c "
 import requests


### PR DESCRIPTION
## Summary
- install `httpx` in `test_setup.sh`
- generate `test_setup.sh` with `httpx` installed in `setup_environment.sh`

## Testing
- `python - <<'EOF'
import httpx, pytest
print('httpx', httpx.__version__)
print('pytest', pytest.__version__)
EOF`
- `pytest -k test_basic.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_6847b2d57274832ba92521699d1919e4