### PR TITLE
Fix docstring formatting in documentation example

### DIFF
--- a/docs/padroes_documentacao.py
+++ b/docs/padroes_documentacao.py
@@ -100,7 +100,7 @@ class ExampleClass:
 
 # Padrões para Documentação de API
 
-"""
+'''
 Exemplo de documentação para endpoint:
 
 ```python
@@ -147,9 +147,7 @@ async def upload_file(
             "message": "Arquivo enviado com sucesso"
         }
         ```
-    """
-```
-"""
+    '''
 
 # Padrões para README
 


### PR DESCRIPTION
## Summary
- fix closing of API documentation example docstring
- ensure sample documentation compiles

## Testing
- `python -m py_compile docs/padroes_documentacao.py`

------
https://chatgpt.com/codex/tasks/task_b_6847b2d58784832bb51545cefa9034bb