### PR TITLE
Fix conversation message count logic

### DIFF
--- a/src/synapse/api/v1/endpoints/conversations.py
+++ b/src/synapse/api/v1/endpoints/conversations.py
@@ -185,6 +185,7 @@ async def send_message(
     
     # TODO: Processar mensagem com agente e gerar resposta
     # Por enquanto, criar resposta simples
+    agent_response_created = False
     if conversation.agent_id:
         agent_response = Message(
             conversation_id=conversation_id,
@@ -195,9 +196,10 @@ async def send_message(
             processing_time_ms=1000
         )
         db.add(agent_response)
-    
+        agent_response_created = True
+
     # Atualizar estatísticas da conversação
-    conversation.message_count += 1 if not conversation.agent_id else 2
+    conversation.message_count += 2 if agent_response_created else 1
     conversation.last_message_at = func.now()
     
     db.commit()


### PR DESCRIPTION
## Summary
- fix message count updates in conversations when agent responses are created

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_6847b2d6cc08832ba048bf96a7d3a882