### PR TITLE
Add sqlalchemy func import to workflows endpoint

### DIFF
--- a/src/synapse/api/v1/endpoints/workflows.py
+++ b/src/synapse/api/v1/endpoints/workflows.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
 
 from src.synapse.api.deps import get_current_user
 from src.synapse.database import get_db


### PR DESCRIPTION
## Summary
- add `from sqlalchemy.sql import func` to workflow endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_6847b846f628832b959eff45b709c986