### PR TITLE
Add Python version enforcement in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,16 @@ echo "🚀 Iniciando configuração do SynapScale Backend..."
 python_version=$(python3 --version 2>&1 | awk '{print $2}')
 echo "📋 Versão do Python detectada: $python_version"
 
+# Validar se a versão do Python é 3.11 ou superior
+python - "$python_version" <<'EOF'
+import sys
+version = sys.argv[1]
+major, minor = (int(x) for x in version.split('.')[:2])
+if (major, minor) < (3, 11):
+    print(f"❌ Python 3.11 ou superior é necessário. Versão detectada: {version}")
+    sys.exit(1)
+EOF
+
 # Criar ambiente virtual
 echo "🔧 Criando ambiente virtual..."
 python3 -m venv venv


### PR DESCRIPTION
## Summary
- validate Python version in `setup.sh`

## Testing
- `bash -n setup.sh`
- `pytest -q` *(fails: ModuleNotFoundError for `src`)*

------
https://chatgpt.com/codex/tasks/task_b_6847b59b186c832ba4c8d53911c616e7