### PR TITLE
Ensure models imported before DB init

### DIFF
--- a/docs/padroes_documentacao.py
+++ b/docs/padroes_documentacao.py
@@ -100,7 +100,7 @@ class ExampleClass:
 
 # Padrões para Documentação de API
 
-"""
+'''
 Exemplo de documentação para endpoint:
 
 ```python
@@ -149,7 +149,7 @@ async def upload_file(
         ```
     """
 ```
-"""
+'''
 
 # Padrões para README
 

--- a/src/synapse/core/database_new.py
+++ b/src/synapse/core/database_new.py
@@ -13,6 +13,9 @@ from contextlib import contextmanager
 
 from .config_new import settings
 
+# Importar todos os modelos para garantir que estejam registrados
+from ..models import *  # noqa: F401,F403
+
 logger = logging.getLogger(__name__)
 
 # Base para modelos SQLAlchemy
@@ -183,9 +186,6 @@ def init_database():
     """
     try:
         engine = create_database_engine()
-        
-        # Importar todos os modelos para garantir que estejam registrados
-        from ..models import *
         
         # Criar tabelas
         Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- move `from ..models import *` to module top in `database_new.py`
- fix docs syntax to allow repository compilation

## Testing
- `python -m py_compile src/synapse/core/database_new.py`
- `git ls-files '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_b_6847b80e6564832b8b781f507f67c66b