### PR TITLE
Fix invalid Execution relationships

### DIFF
--- a/src/synapse/models/agent.py
+++ b/src/synapse/models/agent.py
@@ -71,7 +71,6 @@ class Agent(Base):
     user = relationship("User", back_populates="agents")
     workspace = relationship("Workspace", back_populates="agents")
     conversations = relationship("Conversation", back_populates="agent", cascade="all, delete-orphan")
-    executions = relationship("Execution", back_populates="agent")
 
     def to_dict(self, include_sensitive: bool = False) -> dict:
         """Converte agente para dicionário"""

--- a/src/synapse/models/workflow.py
+++ b/src/synapse/models/workflow.py
@@ -43,8 +43,9 @@ class Workflow(Base):
     workspace = relationship("Workspace", back_populates="workflows")
     workflow_nodes = relationship("WorkflowNode", back_populates="workflow", cascade="all, delete-orphan")
     connections = relationship("WorkflowConnection", back_populates="workflow", cascade="all, delete-orphan")
-    executions = relationship("Execution", back_populates="workflow", cascade="all, delete-orphan")
-    workflow_executions = relationship("WorkflowExecution", back_populates="workflow", cascade="all, delete-orphan")
+    executions = relationship(
+        "WorkflowExecution", back_populates="workflow", cascade="all, delete-orphan"
+    )
 
     def to_dict(self, include_definition: bool = True) -> dict:
         """Converte workflow para dicionário"""


### PR DESCRIPTION
## Summary
- correct Workflow model relationship to WorkflowExecution
- remove unused executions relationship from Agent model

## Testing
- `pytest -q` *(fails: SECRET_KEY deve ser definida com pelo menos 32 caracteres; JWT_SECRET_KEY deve ser definida com pelo menos 32 caracteres; Configuração SMTP necessária para notificações por email; Pelo menos um provedor LLM deve ser configurado)*

------
https://chatgpt.com/codex/tasks/task_b_6847fc7fc204832bb301a0c5dd198712