### PR TITLE
fix: add nodes relationship to Workspace

### DIFF
--- a/src/synapse/models/workspace.py
+++ b/src/synapse/models/workspace.py
@@ -86,6 +86,7 @@ class Workspace(Base):
     invitations = relationship("WorkspaceInvitation", back_populates="workspace", cascade="all, delete-orphan")
     activities = relationship("WorkspaceActivity", back_populates="workspace", cascade="all, delete-orphan")
     workflows = relationship("Workflow", back_populates="workspace", cascade="all, delete-orphan")
+    nodes = relationship("Node", back_populates="workspace", cascade="all, delete-orphan")
     
     def __repr__(self):
         return f"<Workspace(id={self.id}, name='{self.name}', owner_id={self.owner_id})>"


### PR DESCRIPTION
## Summary
- include nodes relationship on Workspace model to resolve mapper init errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_684808593d04832b85d5c50e3fd8f4ca