### PR TITLE
Fix Mapper initialization by removing unused relationship

### DIFF
--- a/src/synapse/models/node.py
+++ b/src/synapse/models/node.py
@@ -67,7 +67,6 @@ class Node(Base):
     user = relationship("User", back_populates="nodes")
     workspace = relationship("Workspace", back_populates="nodes")
     workflow_instances = relationship("WorkflowNode", back_populates="node")
-    marketplace_listings = relationship("MarketplaceListing", back_populates="node")
 
     def to_dict(self, include_code: bool = True) -> dict:
         """Converte node para dicionário"""


### PR DESCRIPTION
## Summary
- remove unused `MarketplaceListing` relationship from Node model

## Testing
- `pytest -q` *(fails: SECRET_KEY deve ser definida com pelo menos 32 caracteres ...)*

------
https://chatgpt.com/codex/tasks/task_b_68481adadfd8832b8a63a6b0c5ca51d4