### PR TITLE
Fix Node model mapping error

### DIFF
--- a/src/synapse/models/node.py
+++ b/src/synapse/models/node.py
@@ -67,7 +67,8 @@ class Node(Base):
     user = relationship("User", back_populates="nodes")
     workspace = relationship("Workspace", back_populates="nodes")
     workflow_instances = relationship("WorkflowNode", back_populates="node")
-    marketplace_listings = relationship("MarketplaceListing", back_populates="node")
+    # Relacionamento com listagens de marketplace ainda não implementado
+    # marketplace_listings = relationship("MarketplaceListing", back_populates="node")
 
     def to_dict(self, include_code: bool = True) -> dict:
         """Converte node para dicionário"""


### PR DESCRIPTION
## Summary
- remove reference to missing MarketplaceListing model in Node

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68485386da20832baa49f8d6e6834ea4